### PR TITLE
Migrate from base to core 2.0.0

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -1,0 +1,22 @@
+name: App build
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review, unlabeled]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - uses: caffeinelabs/setup-mops@v1
+
+      - name: Make sure moc is installed
+        run: mops toolchain bin moc || mops toolchain use moc latest
+
+      - name: Show mops version
+        run: mops -v
+
+      - name: Run mops test
+        run: mops test

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review, unlabeled]
 
+env:
+  dfx_version: 0.30.1
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -11,6 +14,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - uses: caffeinelabs/setup-mops@v1
+
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: ${{ env.dfx_version }}
+
+      - name: Confirm dfx version
+        run: dfx --version
 
       - name: Make sure moc is installed
         run: mops toolchain bin moc || mops toolchain use moc latest

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -20,3 +20,7 @@ jobs:
 
       - name: Run mops test
         run: mops test
+
+      - name: Run example
+        working-directory: ./example
+        run: mops bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Mops-bench changelog
+
+## Next
+
+* Migrate from base to core 2.0.0
+
+## 1.0.0
+
+* Inital version

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![mops](https://oknww-riaaa-aaaam-qaf6a-cai.raw.ic0.app/badge/mops/bench)](https://mops.one/bench)
+[![documentation](https://oknww-riaaa-aaaam-qaf6a-cai.raw.ic0.app/badge/documentation/bench)](https://mops.one/bench/docs)
+
 # Motoko Benchmarking
 
 Easy way to benchmark the Motoko code with `mops bench`.

--- a/bench/simple.bench.mo
+++ b/bench/simple.bench.mo
@@ -1,33 +1,34 @@
+import List "mo:core/List";
 import Nat "mo:core/Nat";
-import Buffer "mo:base/Buffer";
-import Vector "mo:vector/Class";
+import PureList "mo:core/pure/List";
+import Runtime "mo:core/Runtime";
 import Bench "../src";
 
 module {
 	public func init() : Bench.Bench {
 		let bench = Bench.Bench();
 
-		bench.name("Vector vs Buffer");
+		bench.name("List vs PureList");
 		bench.description("Add items one-by-one");
 
-		bench.rows(["Vector", "Buffer"]);
+		bench.rows(["List", "PureList"]);
 		bench.cols(["10", "10000", "1000000"]);
 
 		bench.runner(func(row, col) {
-			let ?n = Nat.fromText(col);
+			let ?n = Nat.fromText(col) else Runtime.trap("Invalid column value: " # col);
 
 			// Vector
-			if (row == "Vector") {
-				let vec = Vector.Vector<Nat>();
+			if (row == "List") {
+				let list = List.empty<Nat>();
 				for (i in Nat.range(1, n+1)) {
-					vec.add(i);
+					list.add(i);
 				};
 			}
 			// Buffer
-			else if (row == "Buffer") {
-				let buf = Buffer.Buffer<Nat>(0);
+			else if (row == "PureList") {
+				var list = PureList.empty<Nat>();
 				for (i in Nat.range(1, n+1)) {
-					buf.add(i);
+					list := list.pushFront(i);
 				};
 			};
 		});

--- a/bench/simple.bench.mo
+++ b/bench/simple.bench.mo
@@ -1,5 +1,4 @@
-import Nat "mo:base/Nat";
-import Iter "mo:base/Iter";
+import Nat "mo:core/Nat";
 import Buffer "mo:base/Buffer";
 import Vector "mo:vector/Class";
 import Bench "../src";
@@ -20,14 +19,14 @@ module {
 			// Vector
 			if (row == "Vector") {
 				let vec = Vector.Vector<Nat>();
-				for (i in Iter.range(1, n)) {
+				for (i in Nat.range(1, n+1)) {
 					vec.add(i);
 				};
 			}
 			// Buffer
 			else if (row == "Buffer") {
 				let buf = Buffer.Buffer<Nat>(0);
-				for (i in Iter.range(1, n)) {
+				for (i in Nat.range(1, n+1)) {
 					buf.add(i);
 				};
 			};

--- a/example/bench/simple.bench.mo
+++ b/example/bench/simple.bench.mo
@@ -2,13 +2,13 @@ import List "mo:core/List";
 import Nat "mo:core/Nat";
 import PureList "mo:core/pure/List";
 import Runtime "mo:core/Runtime";
-import Bench "../src";
+import Bench "mo:bench";
 
 module {
 	public func init() : Bench.Bench {
 		let bench = Bench.Bench();
 
-		bench.name("List vs PureList");
+		bench.name("List vss PureList");
 		bench.description("Add items one-by-one");
 
 		bench.rows(["List", "PureList"]);

--- a/example/mops.toml
+++ b/example/mops.toml
@@ -2,6 +2,7 @@
 core = "2.0.0"
 
 [dev-dependencies]
+base = "0.16.0"
 bench = "https://github.com/research-ag/mops-bench#maintenance"
 
 [toolchain]

--- a/example/mops.toml
+++ b/example/mops.toml
@@ -1,0 +1,9 @@
+[dependencies]
+core = "2.0.0"
+
+[dev-dependencies]
+base = "0.16.0"
+bench = "https://github.com/research-ag/mops-bench#maintenance"
+
+[toolchain]
+moc = "1.0.0"

--- a/example/mops.toml
+++ b/example/mops.toml
@@ -2,7 +2,6 @@
 core = "2.0.0"
 
 [dev-dependencies]
-base = "0.16.0"
 bench = "https://github.com/research-ag/mops-bench#maintenance"
 
 [toolchain]

--- a/mops.toml
+++ b/mops.toml
@@ -12,6 +12,3 @@ core = "2.0.0"
 [toolchain]
 moc = "1.0.0"
 wasmtime = "40.0.0"
-
-[dev-dependencies]
-bench = "1.0.0"

--- a/mops.toml
+++ b/mops.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [dependencies]
 core = "2.0.0"
+base = "0.16.0"
 
 [toolchain]
 moc = "1.0.0"

--- a/mops.toml
+++ b/mops.toml
@@ -7,7 +7,12 @@ keywords = [ "bench", "benchmark", "performance", "profiling", "mops" ]
 license = "MIT"
 
 [dependencies]
-base = "0.10.1"
+core = "2.0.0"
+
+[toolchain]
+moc = "1.0.0"
+wasmtime = "40.0.0"
 
 [dev-dependencies]
 vector = "0.2.0"
+base = "0.16.0"

--- a/mops.toml
+++ b/mops.toml
@@ -8,7 +8,6 @@ license = "MIT"
 
 [dependencies]
 core = "2.0.0"
-base = "0.16.0"
 
 [toolchain]
 moc = "1.0.0"

--- a/mops.toml
+++ b/mops.toml
@@ -2,7 +2,7 @@
 name = "bench"
 version = "1.0.0"
 description = "Motoko benchmarking with Mops"
-repository = "https://github.com/dfinity/mops-bench"
+repository = "https://github.com/caffeinelabs/mops-bench"
 keywords = [ "bench", "benchmark", "performance", "profiling", "mops" ]
 license = "MIT"
 
@@ -14,5 +14,4 @@ moc = "1.0.0"
 wasmtime = "40.0.0"
 
 [dev-dependencies]
-vector = "0.2.0"
-base = "0.16.0"
+bench = "1.0.0"

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -38,32 +38,32 @@ module {
 	};
 
 	public class Bench() {
-		var _name = "";
-		var _description = "";
-		var _rows : [Text] = [];
-		var _cols : [Text] = [];
-		var _runner = func(row : Text, col : Text) {};
+		var name_ = "";
+		var description_ = "";
+		var rows_ : [Text] = [];
+		var cols_ : [Text] = [];
+		var runner_ = func(_row : Text, _col : Text) {};
 
 		// public let heap : BenchHeap = BenchHeap();
 
 		public func name(value : Text) {
-			_name := value;
+			name_ := value;
 		};
 
 		public func description(value : Text) {
-			_description := value;
+			description_ := value;
 		};
 
 		public func rows(value : [Text]) {
-			_rows := value;
+			rows_ := value;
 		};
 
 		public func cols(value : [Text]) {
-			_cols := value;
+			cols_ := value;
 		};
 
 		public func runner(fn : (row : Text, col : Text) -> ()) {
-			_runner := fn;
+			runner_ := fn;
 		};
 
 		// INTERNAL
@@ -73,17 +73,17 @@ module {
 
 		public func getSchema() : BenchSchema {
 			{
-				name = _name;
-				description = _description;
-				rows = _rows;
-				cols = _cols;
+				name = name_;
+				description = description_;
+				rows = rows_;
+				cols = cols_;
 			}
 		};
 
 		public func runCell(rowIndex : Nat, colIndex : Nat) {
-			let row = _rows.get(rowIndex);
-			let col = _cols.get(colIndex);
-			_runner(row, col);
+			let row = rows_.get(rowIndex);
+			let col = cols_.get(colIndex);
+			runner_(row, col);
 		};
 	};
 };

--- a/test/lib.test.mo
+++ b/test/lib.test.mo
@@ -1,34 +1,36 @@
+import List "mo:core/List";
 import Nat "mo:core/Nat";
+import PureList "mo:core/pure/List";
 import Runtime "mo:core/Runtime";
-import Buffer "mo:base/Buffer";
-import Vector "mo:vector/Class";
 import Bench "../src";
 
 let bench = Bench.Bench();
 
-bench.name("Vector vs Buffer");
+bench.name("List vs PureList");
 bench.description("Add items one-by-one");
 
-bench.rows(["Vector", "Buffer"]);
+bench.rows(["List", "PureList"]);
 bench.cols(["10", "10000", "1000000"]);
 
-bench.runner(func(row, col) {
-	let ?n = Nat.fromText(col) else Runtime.trap("Invalid column value: " # col);
+bench.runner(
+	func(row, col) {
+		let ?n = Nat.fromText(col) else Runtime.trap("Invalid column value: " # col);
 
-	// Vector
-	if (row == "Vector") {
-		let vec = Vector.Vector<Nat>();
-		for (i in Nat.range(1, n+1)) {
-			vec.add(i);
+		// Vector
+		if (row == "List") {
+			let list = List.empty<Nat>();
+			for (i in Nat.range(1, n + 1)) {
+				list.add(i);
+			};
+		}
+		// Buffer
+		else if (row == "PureList") {
+			var list = PureList.empty<Nat>();
+			for (i in Nat.range(1, n + 1)) {
+				list := list.pushFront(i);
+			};
 		};
 	}
-	// Buffer
-	else if (row == "Buffer") {
-		let buf = Buffer.Buffer<Nat>(0);
-		for (i in Nat.range(1, n+1)) {
-			buf.add(i);
-		};
-	};
-});
+);
 
 bench.runCell(0, 0);

--- a/test/lib.test.mo
+++ b/test/lib.test.mo
@@ -1,5 +1,5 @@
-import Nat "mo:base/Nat";
-import Iter "mo:base/Iter";
+import Nat "mo:core/Nat";
+import Runtime "mo:core/Runtime";
 import Buffer "mo:base/Buffer";
 import Vector "mo:vector/Class";
 import Bench "../src";
@@ -13,19 +13,19 @@ bench.rows(["Vector", "Buffer"]);
 bench.cols(["10", "10000", "1000000"]);
 
 bench.runner(func(row, col) {
-	let ?n = Nat.fromText(col);
+	let ?n = Nat.fromText(col) else Runtime.trap("Invalid column value: " # col);
 
 	// Vector
 	if (row == "Vector") {
 		let vec = Vector.Vector<Nat>();
-		for (i in Iter.range(1, n)) {
+		for (i in Nat.range(1, n+1)) {
 			vec.add(i);
 		};
 	}
 	// Buffer
 	else if (row == "Buffer") {
 		let buf = Buffer.Buffer<Nat>(0);
-		for (i in Iter.range(1, n)) {
+		for (i in Nat.range(1, n+1)) {
 			buf.add(i);
 		};
 	};


### PR DESCRIPTION
See `example` directory how users can use this upgraded version.

Note that `mops` itself also needs to upgrade in order to eliminate all base dependency in the ephemeral canisters that run during benchmarking. Until that happens users still need
```
[dev-dependencies]
base = "0.16.0"
```
in their mops.toml. When they run the future version of mops then they can remove that line.

The full `mops.toml` will look like this (assuming this new`bench` version gets published as version `1.0.1`):
```
[dependencies]
core = "2.0.0"

[dev-dependencies]
bench = "1.0.1"
base = "0.16.0"
```
Here, `bench` is a dependency of the project benchmark code in the `bench/` directory. Whereas `base` is a dependency of the current `mops` version. This dependency can be removed as soon as the user switches to an upgrades `mops` version that uses `core` internally.