### PR TITLE
Update to 2.0.1 with `core` listed as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mops-bench changelog
 
+## 2.0.1
+
+* List `core` as dependency
+
 ## 2.0.0
 
 * Migrate from base to core 2.0.0

--- a/mops.toml
+++ b/mops.toml
@@ -1,12 +1,12 @@
 [package]
 name = "bench"
-version = "2.0.0"
+version = "2.0.1"
 description = "Motoko benchmarking with Mops"
 repository = "https://github.com/caffeinelabs/mops-bench"
 keywords = [ "bench", "benchmark", "performance", "profiling", "mops" ]
 license = "MIT"
 
-[dev-dependencies]
+[dependencies]
 core = "2.0.0"
 
 [toolchain]


### PR DESCRIPTION
Rolls back a change in 2.0.0 which listed `core` in `[dev-dependencies]` instead of `[dependencies]`.